### PR TITLE
made ID available for filename templating

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ To install: ``go get -u github.com/otium/ytdl/...``
       - ```res``` - resolution of video
       - ```videnc``` - video encoding
       - ```audenc``` - audio encoding
-      - ```prof``` - youtube video profile
+      - ```itag``` - youtube video profile
       - ```audbr``` - audio bitrate
    - Default filters
       - ```ext:mp4```
@@ -47,8 +47,8 @@ To install: ``go get -u github.com/otium/ytdl/...``
       - ```best```
  - ```--output, -o``` - Output to specific path
    - Supports templates, ex: {{.Title}}.{{.Ext}}
-   - Defaults to ```{{.Title}}.{{.Ext}}```
-   - Supported template variables are Title, Ext, DatePublished, Resolution
+   - Defaults to ```{{.Title}} [{{.ID}}].{{.Ext}}```
+   - Supported template variables are Title, ID, Author, Ext, DatePublished, Resolution, Duration (case sensitive!)
    - Pass - to output to stdout, former stdout output is redirected to stderr
  - ```--info, -i``` - Just gets video info, outputs to stdout
  - ```--no-progress``` - Disables the progress bar

--- a/cmd/ytdl/main.go
+++ b/cmd/ytdl/main.go
@@ -161,23 +161,6 @@ func handler(identifier string, options options) {
 		return
 	}
 
-	if options.infoOnly {
-		fmt.Println("Title:", info.Title)
-		fmt.Println("ID:", info.ID)
-		fmt.Println("Author:", info.Author)
-		fmt.Println("Date Published:", info.DatePublished.Format("Jan 2 2006"))
-		fmt.Println("Duration:", info.Duration)
-		return
-	} else if options.json {
-		var data []byte
-		data, err = json.MarshalIndent(info, "", "\t")
-		if err != nil {
-			err = fmt.Errorf("Unable to marshal json: %s", err.Error())
-			return
-		}
-		fmt.Println(string(data))
-		return
-	}
 
 	formats := info.Formats
 	// parse filter arguments, and filter through formats
@@ -212,8 +195,46 @@ func handler(identifier string, options options) {
 		}
 		return
 	}
+    
+    var fileName string
+    fileName, err = createFileName(options.outputFile, outputFileName{
+        Title:         sanitizeFileNamePart(info.Title),
+        ID:            sanitizeFileNamePart(info.ID),
+        Ext:           sanitizeFileNamePart(format.Extension),
+        DatePublished: sanitizeFileNamePart(info.DatePublished.Format("2006-01-02")),
+        Resolution:    sanitizeFileNamePart(format.Resolution),
+        Author:        sanitizeFileNamePart(info.Author),
+        Duration:      sanitizeFileNamePart(info.Duration.String()),
+    })
+    if err != nil {
+        err = fmt.Errorf("Unable to parse output file file name: %s", err.Error())
+        return
+    } 		
+	
+    if options.infoOnly {
+        fmt.Println("Title:", info.Title)
+		fmt.Println("ID:", info.ID)
+		fmt.Println("Author:", info.Author)
+		fmt.Println("Date Published:", info.DatePublished.Format("Jan 2 2006"))
+		fmt.Println("Duration:", info.Duration)
+        if options.outputFile != "-" {
+            fmt.Println("Filename:", fileName)
+        }
+		return
+	} else if options.json {
+		var data []byte
+		data, err = json.MarshalIndent(info, "", "\t")
+		if err != nil {
+			err = fmt.Errorf("Unable to marshal json: %s", err.Error())
+			return
+		}
+		fmt.Println(string(data))
+		return
+	}
+    
 	if out == nil {
-		var fileName string
+		/*
+        var fileName string
 		fileName, err = createFileName(options.outputFile, outputFileName{
 			Title:         sanitizeFileNamePart(info.Title),
 			ID:            sanitizeFileNamePart(info.ID),
@@ -226,7 +247,8 @@ func handler(identifier string, options options) {
 		if err != nil {
 			err = fmt.Errorf("Unable to parse output file file name: %s", err.Error())
 			return
-		}
+		} 
+        */
 		// Create file truncate if append flag is not set
 		flags := os.O_CREATE | os.O_WRONLY
 		if options.append {

--- a/cmd/ytdl/main.go
+++ b/cmd/ytdl/main.go
@@ -46,7 +46,7 @@ func main() {
 		cli.StringFlag{
 			Name:  "output, o",
 			Usage: "Write output to a file, passing - outputs to stdout",
-			Value: "{{.Title}}.{{.Ext}}",
+			Value: "{{.Title}} [{{.ID}}].{{.Ext}}",
 		},
 		cli.BoolFlag{
 			Name:  "info, i",
@@ -163,6 +163,7 @@ func handler(identifier string, options options) {
 
 	if options.infoOnly {
 		fmt.Println("Title:", info.Title)
+		fmt.Println("ID:", info.ID)
 		fmt.Println("Author:", info.Author)
 		fmt.Println("Date Published:", info.DatePublished.Format("Jan 2 2006"))
 		fmt.Println("Duration:", info.Duration)
@@ -215,6 +216,7 @@ func handler(identifier string, options options) {
 		var fileName string
 		fileName, err = createFileName(options.outputFile, outputFileName{
 			Title:         sanitizeFileNamePart(info.Title),
+			ID:            sanitizeFileNamePart(info.ID),
 			Ext:           sanitizeFileNamePart(format.Extension),
 			DatePublished: sanitizeFileNamePart(info.DatePublished.Format("2006-01-02")),
 			Resolution:    sanitizeFileNamePart(format.Resolution),

--- a/cmd/ytdl/utils.go
+++ b/cmd/ytdl/utils.go
@@ -63,6 +63,7 @@ func parseFilter(filterString string) (func(ytdl.FormatList) ytdl.FormatList, er
 
 type outputFileName struct {
 	Title         string
+	ID            string
 	Author        string
 	Ext           string
 	DatePublished string

--- a/cmd/ytdl/utils.go
+++ b/cmd/ytdl/utils.go
@@ -86,10 +86,23 @@ func createFileName(template string, values outputFileName) (string, error) {
 	return string(buf.String()), nil
 }
 
-var illegalFileNameCharacters = regexp.MustCompile(`[^[a-zA-Z0-9]-_]`)
-
 func sanitizeFileNamePart(part string) string {
-	part = strings.Replace(part, "/", "-", -1)
-	part = illegalFileNameCharacters.ReplaceAllString(part, "")
-	return part
+	
+    // this should satisfy unix
+    part = strings.Replace(part, "/", "-", -1)
+	
+    // some additional replacements for windows
+	part = strings.Replace(part, "\\", "-", -1)
+    part = strings.Replace(part, ":", "-", -1)
+	part = strings.Replace(part, "|", "#", -1)
+	part = strings.Replace(part, ">", "#", -1)
+	part = strings.Replace(part, "<", "#", -1)
+	part = strings.Replace(part, "*", "#", -1)
+	part = strings.Replace(part, "?", ".", -1)
+    
+    // everything not alphanumeric or _.,;#<blank> will be removed here
+    catchUnsafeChars := regexp.MustCompile("[^a-zA-Z0-9-_.,;# ]")
+	part = catchUnsafeChars.ReplaceAllString(part, "")
+	
+    return part
 }

--- a/video_info_test.go
+++ b/video_info_test.go
@@ -9,8 +9,10 @@ import (
 func TestVideoInfo(t *testing.T) {
 	testCases := map[string]bool{
 		"https://www.youtube.com/watch?v=YQHsXMglC9A":            true,
-		"https://www.youtube.com/watch?v=H-30B0cqh88":            true,
 		"https://www.youtube.com/watch?v=qD8hOJoOGtk":            true,
+		"https://www.youtube.com/watch?v=H-30B0cqh88":            true,
+        // testable only in e.g. germany, because there's some rights-control issues in order this video evals 'false'
+		// "https://www.youtube.com/watch?v=FrG4TEcSuRg":            false,
 		"https://www.youtube.com/":                               false,
 		"https://www.youtube.com/watch?v=qHGTs1NSB1s":            true,
 		"https://www.facebook.com/video.php?v=10153820411888896": false,
@@ -24,8 +26,9 @@ func TestVideoInfo(t *testing.T) {
 	}
 }
 
+
 func TestDownloadVideo(t *testing.T) {
-	info, err := GetVideoInfo("https://www.youtube.com/watch?v=FrG4TEcSuRg")
+	info, err := GetVideoInfo("https://www.youtube.com/watch?v=WZb4lIvbRgQ")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -37,7 +40,7 @@ func TestDownloadVideo(t *testing.T) {
 }
 
 func TestThumbnail(t *testing.T) {
-	info, err := GetVideoInfo("https://www.youtube.com/watch?v=FrG4TEcSuRg")
+	info, err := GetVideoInfo("https://www.youtube.com/watch?v=WZb4lIvbRgQ")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
heyho :)

as I recognize the youtube ID as the one unique identifier, I've got used to put it in the filename whenever a clip I've dl'ed originates off youtube... and as making this available for 'ytdl' was such a miniscule change, writing this comment actually took almost twice as long :D 

...I've got some more modification regarding 'info verbosity' and maybe some 'shortcut' calls already in the pipeline which I'll ponder upon until I've got the spare time to actually go coding...
