### PR TITLE
Fix the documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ------
 Go library for downloading YouTube videos
 
-[Documentation: https://godoc.org/github.com/otium/ytdl](https://godoc.org/github.com/otium/rylio "ytdl")
+[Documentation: https://godoc.org/github.com/rylio/ytdl](https://godoc.org/github.com/rylio/ytdl "ytdl")
 
 ## Example
 


### PR DESCRIPTION
The link is sort of pointless, but since it exists let's make it point to the right page.