### PR TITLE
rename Sirupsen to lowercase sirupsen

### DIFF
--- a/cmd/ytdl/main.go
+++ b/cmd/ytdl/main.go
@@ -11,7 +11,7 @@ import (
 
 	"encoding/json"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/cheggaaa/pb"
 	"github.com/codegangsta/cli"
 	"github.com/mattn/go-colorable"

--- a/video_info.go
+++ b/video_info.go
@@ -16,7 +16,7 @@ import (
 	"time"
 
 	"github.com/PuerkitoBio/goquery"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 const youtubeBaseURL = "https://www.youtube.com/watch"


### PR DESCRIPTION
Please see the discussion here [https://github.com/sirupsen/logrus/issues/543](). The package should be used with a lower case s. 