### PR TITLE
Fix parsing signature error

### DIFF
--- a/signature.go
+++ b/signature.go
@@ -91,7 +91,7 @@ const (
 		"a\\.splice\\(0,b\\)" +
 		"\\}"
 	swapStr = ":function\\(a,b\\)\\{" +
-		"var c=a\\[0\\];a\\[0\\]=a\\[b%a\\.length\\];a\\[b(?:%a\\.length)?\\]=c(?:;return a)?" +
+		"var c=a\\[0\\];a\\[0\\]=a\\[b(?:%a\\.length)?\\];a\\[b(?:%a\\.length)?\\]=c(?:;return a)?" +
 		"\\}"
 )
 

--- a/video_info_test.go
+++ b/video_info_test.go
@@ -35,6 +35,7 @@ func TestGetDownloadURL(t *testing.T) {
 		"https://www.youtube.com/watch?v=aQZDbBGBJsM",
 		"https://www.youtube.com/watch?v=cRS4mS4gKwg",
 		"https://www.youtube.com/watch?v=0fllyJTBsRU",
+		"https://www.youtube.com/watch?v=yx0PEdDCle4",
 	}
 	for _, url := range testCases {
 		info, err := GetVideoInfo(url)


### PR DESCRIPTION
I ran into this error. https://github.com/rylio/ytdl/blob/ec14f9766f7a9500eec011c8777cbdf912454a56/signature.go#L141
When I looked inside the issues, I saw a closed PR https://github.com/rylio/ytdl/issues/38. But I Still got the error. To fix this issue I used the swapStr from node-ytdl-core repo 
https://github.com/fent/node-ytdl-core/blob/master/lib/sig.js#L109

After implementing it, I didn't get the error anymore. I've added a testcase as well.

---
#### Steps to reproduce
Try downloding this URL https://www.youtube.com/watch?v=yx0PEdDCle4