### PR TITLE
add runtime download option feature and fixed #47

### DIFF
--- a/cmd/ytdl/main.go
+++ b/cmd/ytdl/main.go
@@ -18,10 +18,7 @@ import (
 	"github.com/rylio/ytdl"
 	log "github.com/sirupsen/logrus"
 	"github.com/olekukonko/tablewriter"
-	"sort"
 )
-
-type byResolution [][]string
 
 type options struct {
 	noProgress     bool
@@ -197,17 +194,17 @@ func handler(identifier string, options options) {
 	} else if options.downloadOption {
 		var data [][]string
 
+		info.Formats.Sort(ytdl.FormatResolutionKey, true)
 		for _, format := range info.Formats {
 			var fps string
-			if format.AccessMeta("fps") == nil {
+			if format.ValueForKey("fps") == nil {
 				fps = "n/a"
 			} else {
-				fps = format.AccessMeta("fps").(string)
+				fps = format.ValueForKey("fps").(string)
 			}
 
 			data = append(data, []string{strconv.Itoa(format.Itag), format.Extension, format.Resolution, fps, format.VideoEncoding, format.AudioEncoding, strconv.Itoa(format.AudioBitrate)})
 		}
-		sort.Sort(byResolution(data))
 
 		table := tablewriter.NewWriter(os.Stdout)
 		table.SetHeader([]string{"itag", "ext", "res", "fps", "vEncoding", "aEncoding", "aBitrate"})
@@ -337,26 +334,4 @@ func handler(identifier string, options options) {
 		out = io.MultiWriter(out, progressBar)
 	}
 	_, err = io.Copy(out, resp.Body)
-}
-
-func (s byResolution) Len() int {
-	return len(s)
-}
-func (s byResolution) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-func (s byResolution) Less(i, j int) bool {
-	if s[i][2] == "" {
-		return false
-	} else if s[j][2] == "" {
-		return true
-	}
-
-	if len(s[i][2]) < len(s[j][2]) {
-		return false
-	} else if len(s[i][2]) > len(s[j][2]) {
-		return true
-	}
-
-	return s[i][2] > s[j][2]
 }

--- a/cmd/ytdl/main.go
+++ b/cmd/ytdl/main.go
@@ -198,12 +198,19 @@ func handler(identifier string, options options) {
 		var data [][]string
 
 		for _, format := range info.Formats {
-			data = append(data, []string{strconv.Itoa(format.Itag), format.Extension, format.Resolution, format.VideoEncoding, format.AudioEncoding, strconv.Itoa(format.AudioBitrate)})
+			var fps string
+			if format.AccessMeta("fps") == nil {
+				fps = "n/a"
+			} else {
+				fps = format.AccessMeta("fps").(string)
+			}
+
+			data = append(data, []string{strconv.Itoa(format.Itag), format.Extension, format.Resolution, fps, format.VideoEncoding, format.AudioEncoding, strconv.Itoa(format.AudioBitrate)})
 		}
 		sort.Sort(byResolution(data))
 
 		table := tablewriter.NewWriter(os.Stdout)
-		table.SetHeader([]string{"itag", "ext", "res", "vEncoding", "aEncoding", "aBitrate"})
+		table.SetHeader([]string{"itag", "ext", "res", "fps", "vEncoding", "aEncoding", "aBitrate"})
 
 		for _, v := range data {
 			table.Append(v)

--- a/cmd/ytdl/utils.go
+++ b/cmd/ytdl/utils.go
@@ -18,6 +18,10 @@ func parseFilter(filterString string) (func(ytdl.FormatList) ytdl.FormatList, er
 		return func(formats ytdl.FormatList) ytdl.FormatList {
 			return formats.Extremes(ytdl.FormatResolutionKey, filterString == "best").Extremes(ytdl.FormatAudioBitrateKey, filterString == "best")
 		}, nil
+	case "best-fps", "worst-fps":
+		return func(formats ytdl.FormatList) ytdl.FormatList {
+			return formats.Extremes(ytdl.FormatFPSKey, filterString == "best-fps").Extremes(ytdl.FormatResolutionKey, filterString == "best-fps").Extremes(ytdl.FormatAudioBitrateKey, filterString == "best-fps")
+		}, nil
 	case "best-video", "worst-video":
 		return func(formats ytdl.FormatList) ytdl.FormatList {
 			return formats.Extremes(ytdl.FormatResolutionKey, strings.HasPrefix(filterString, "best"))

--- a/format.go
+++ b/format.go
@@ -77,6 +77,10 @@ func (f Format) CompareKey(other Format, key FormatKey) int {
 	}
 }
 
+func (f Format) AccessMeta(field string) interface{} {
+	return f.meta[field]
+}
+
 // FORMATS is a map of all itags and their formats
 var FORMATS = map[int]Format{
 	5: Format{

--- a/format.go
+++ b/format.go
@@ -13,6 +13,7 @@ const (
 	FormatAudioEncodingKey FormatKey = "audenc"
 	FormatItagKey          FormatKey = "itag"
 	FormatAudioBitrateKey  FormatKey = "audbr"
+	FormatFPSKey           FormatKey = "fps"
 )
 
 // Format is a youtube is a static youtube video format
@@ -72,13 +73,19 @@ func (f Format) CompareKey(other Format, key FormatKey) int {
 		return res1 - res2
 	case FormatAudioBitrateKey:
 		return f.ValueForKey(key).(int) - other.ValueForKey(key).(int)
+	case FormatFPSKey:
+		if f.ValueForKey(key) == nil {
+			return -1
+		} else if other.ValueForKey(key) == nil {
+			return 1
+		} else {
+			a, _ := strconv.Atoi(f.ValueForKey(key).(string))
+			b, _ := strconv.Atoi(other.ValueForKey(key).(string))
+			return a - b
+		}
 	default:
 		return 0
 	}
-}
-
-func (f Format) AccessMeta(field string) interface{} {
-	return f.meta[field]
 }
 
 // FORMATS is a map of all itags and their formats


### PR DESCRIPTION
Now we can use "download-option, p" flag to let us see download options available for the video we'd like to download and download the desired one after entering the itag number.