### PR TITLE
Youtube api update

### DIFF
--- a/signature.go
+++ b/signature.go
@@ -48,7 +48,7 @@ func getDownloadURL(format Format, htmlPlayerFile string) (*url.URL, error) {
 	query := u.Query()
 	query.Set("ratebypass", "yes")
 	if len(sig) > 0 {
-		query.Set("signature", sig)
+		query.Set("sig", sig)
 	}
 	u.RawQuery = query.Encode()
 	return u, nil

--- a/signature.go
+++ b/signature.go
@@ -48,7 +48,12 @@ func getDownloadURL(format Format, htmlPlayerFile string) (*url.URL, error) {
 	query := u.Query()
 	query.Set("ratebypass", "yes")
 	if len(sig) > 0 {
-		query.Set("sig", sig)
+		sigParam := "signature"
+		if v, ok := format.meta["sp"].(string); ok && v != "" {
+			sigParam = v
+		}
+
+		query.Set(sigParam, sig)
 	}
 	u.RawQuery = query.Encode()
 	return u, nil


### PR DESCRIPTION
Seems like youtube is migrating ?signature= to ?sig=, a bunch of videos are returning 403's for all formats while others work perfectly fine.

Changing the param to `sig` fixed the 403's and didn't break the ones that worked with `signature`.

I'm not sure about all of this, so... yeah. 