### PR TITLE
Fix #89

### DIFF
--- a/video_info.go
+++ b/video_info.go
@@ -129,7 +129,7 @@ func (c *Client) Download(cx context.Context, info *VideoInfo, format *Format, d
 }
 
 var (
-	regexpPlayerConfig          = regexp.MustCompile("ytplayer.config = (.*?);ytplayer.load")
+	regexpPlayerConfig          = regexp.MustCompile("ytplayer.config = (.*?);ytplayer")
 	regexpInitialData           = regexp.MustCompile(`\["ytInitialData"\] = (.+);`)
 	regexpInitialPlayerResponse = regexp.MustCompile(`\["ytInitialPlayerResponse"\] = (.+);`)
 )


### PR DESCRIPTION
May fix #89. `ytplayer.web_player_context_config` is between `ytplayer.config` and `ytplayer.load` for some video, leads to invalid json error.

I'm not sure all videos have `ytplayer.web_player_context_config` so I simply left `ytplayer`.