### PR TITLE
Fixes issue with json unmarshaling

### DIFF
--- a/video_info.go
+++ b/video_info.go
@@ -138,7 +138,11 @@ func getVideoInfoFromHTML(id string, html []byte) (*VideoInfo, error) {
 	if matches := regexpInitialData.FindSubmatch(html); len(matches) > 0 {
 		data := initialData{}
 
-		if err := json.Unmarshal(matches[1], &data); err != nil {
+		matchString := string(matches[1])
+		matchSplit := strings.Split(matchString, ";ytplayer.web_player_context_config")
+		firstMatch := []byte(matchSplit[0])
+
+		if err := json.Unmarshal(firstMatch, &data); err != nil {
 			return nil, err
 		}
 
@@ -163,7 +167,12 @@ func getVideoInfoFromHTML(id string, html []byte) (*VideoInfo, error) {
 
 	// match json in javascript
 	if matches := regexpPlayerConfig.FindSubmatch(html); len(matches) > 1 {
-		err := json.Unmarshal(matches[1], &jsonConfig)
+
+		matchString := string(matches[1])
+		matchSplit := strings.Split(matchString, ";ytplayer.web_player_context_config")
+		firstMatch := []byte(matchSplit[0])
+
+		err := json.Unmarshal(firstMatch, &jsonConfig)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Turns out the regexp filter doesn't work after and update. I dont
know regexp for shit so just removed the part that is not json.
This is not a permanent fix but guess that this will make fixing
the regexp very easy for a person who knows how regexp works